### PR TITLE
Add a dark foreground color to badges in Pansexual (Dark)

### DIFF
--- a/themes/pansexual-color-theme.json
+++ b/themes/pansexual-color-theme.json
@@ -5,6 +5,7 @@
     "editor.background": "#1e1e1e",
     "editor.foreground": "#20b2ff",
     "activityBarBadge.background": "#ffd800",
+    "activityBarBadge.foreground": "#004282",
     "sideBarTitle.foreground": "#20b2ff",
     "activityBar.background": "#202020",
     "activityBar.foreground": "#20b2ff",


### PR DESCRIPTION
Currently badges are unreadable in the Pansexual (Dark) theme due to the white color on a light background (see image)
![Screenshot 2022-03-04 19 49 50](https://user-images.githubusercontent.com/39284711/156867420-67d2f848-4b61-4883-b60a-094274dc646d.png)
With this change the badge is much actually readable while preserving the look of the theme (see below)
![Screenshot 2022-03-04 20 20 55](https://user-images.githubusercontent.com/39284711/156867454-2e578d23-c948-4d27-b3c1-e99abf0afdcf.png)

